### PR TITLE
Fix #13 calling the correct endpoint for adding a trigger by uniquename

### DIFF
--- a/source/Jobbr.Client/JobbrClient.cs
+++ b/source/Jobbr.Client/JobbrClient.cs
@@ -153,7 +153,7 @@ namespace Jobbr.Client
 
         public T AddTrigger<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase
         {
-            var url = $"jobs/{uniqueName}/triggers/{triggerDto.Id}";
+            var url = $"jobs/{uniqueName}/triggers";
             return this.PostTrigger(triggerDto, url);
         }
 

--- a/source/Jobbr.Server.WebAPI/Controller/Mapping/TriggerMapper.cs
+++ b/source/Jobbr.Server.WebAPI/Controller/Mapping/TriggerMapper.cs
@@ -26,7 +26,7 @@ namespace Jobbr.Server.WebAPI.Controller.Mapping
 
         internal static RecurringTrigger ConvertToTrigger(RecurringTriggerDto dto)
         {
-            var trigger = new RecurringTrigger() { Definition = dto.Definition, StartDateTimeUtc = dto.StartDateTimeUtc, EndDateTimeUtc = dto.EndDateTimeUtc };
+            var trigger = new RecurringTrigger { Definition = dto.Definition, StartDateTimeUtc = dto.StartDateTimeUtc, EndDateTimeUtc = dto.EndDateTimeUtc };
             return (RecurringTrigger)MapCommonValues(dto, trigger);
         }
 
@@ -38,7 +38,7 @@ namespace Jobbr.Server.WebAPI.Controller.Mapping
 
         internal static InstantTrigger ConvertToTrigger(InstantTriggerDto dto)
         {
-            var trigger = new InstantTrigger() { DelayedMinutes = dto.DelayedMinutes };
+            var trigger = new InstantTrigger { DelayedMinutes = dto.DelayedMinutes };
             return (InstantTrigger)MapCommonValues(dto, trigger);
         }
 


### PR DESCRIPTION
The endpoint in the client wasn't configured correctly.