### PR TITLE
Providing interface and async method overloads for JobbrClient

### DIFF
--- a/source/Jobbr.Client/IJobbrClient.cs
+++ b/source/Jobbr.Client/IJobbrClient.cs
@@ -1,5 +1,7 @@
 ﻿using Jobbr.Server.WebAPI.Model;
 
+using System.Threading.Tasks;
+
 namespace Jobbr.Client
 {
     public interface IJobbrClient
@@ -7,16 +9,41 @@ namespace Jobbr.Client
         string Backend { get; }
 
         JobDto GetJob(long id);
+        Task<JobDto> GetJobAsync(long id);
+
+        bool IsAvailable();
+        Task<bool> IsAvailableAsync();
+
         PagedResultDto<JobDto> QueryJobs(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        Task<PagedResultDto<JobDto>> QueryJobsAsync(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+
         PagedResultDto<JobRunDto> QueryJobRuns(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        Task<PagedResultDto<JobRunDto>> QueryJobRunsAsync(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+
         PagedResultDto<JobRunDto> QueryJobRunsByState(string state, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        Task<PagedResultDto<JobRunDto>> QueryJobRunsByStateAsync(string state, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+
         PagedResultDto<JobRunDto> QueryJobRunsByStates(string states, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        Task<PagedResultDto<JobRunDto>> QueryJobRunsByStatesAsync(string states, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+
         PagedResultDto<JobRunDto> QueryJobRunsByUserId(string userId, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string sort = null);
+        Task<PagedResultDto<JobRunDto>> QueryJobRunsByUserIdAsync(string userId, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string sort = null);
+
         T AddTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase;
         T AddTrigger<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase;
+        Task<T> AddTriggerAsync<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase;
+        Task<T> AddTriggerAsync<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase;
+
         T UpdateTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase;
+        Task<T> UpdateTriggerAsync<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase;
+
         T GetTriggerById<T>(long jobId, long triggerId) where T : JobTriggerDtoBase;
+        Task<T> GetTriggerByIdAsync<T>(long jobId, long triggerId) where T : JobTriggerDtoBase;
+
         PagedResultDto<JobRunDto> GetJobRunsByTriggerId(long jobId, long triggerId, int page = 1, int pageSize = 50, string sort = null);
+        Task<PagedResultDto<JobRunDto>> GetJobRunsByTriggerIdAsync(long jobId, long triggerId, int page = 1, int pageSize = 50, string sort = null);
+
         JobRunDto GetJobRunById(long jobRunId);
+        Task<JobRunDto> GetJobRunByIdAsync(long jobRunId);
     }
 }

--- a/source/Jobbr.Client/IJobbrClient.cs
+++ b/source/Jobbr.Client/IJobbrClient.cs
@@ -1,0 +1,22 @@
+﻿using Jobbr.Server.WebAPI.Model;
+
+namespace Jobbr.Client
+{
+    public interface IJobbrClient
+    {
+        string Backend { get; }
+
+        JobDto GetJob(long id);
+        PagedResultDto<JobDto> QueryJobs(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        PagedResultDto<JobRunDto> QueryJobRuns(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        PagedResultDto<JobRunDto> QueryJobRunsByState(string state, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        PagedResultDto<JobRunDto> QueryJobRunsByStates(string states, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null);
+        PagedResultDto<JobRunDto> QueryJobRunsByUserId(string userId, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string sort = null);
+        T AddTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase;
+        T AddTrigger<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase;
+        T UpdateTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase;
+        T GetTriggerById<T>(long jobId, long triggerId) where T : JobTriggerDtoBase;
+        PagedResultDto<JobRunDto> GetJobRunsByTriggerId(long jobId, long triggerId, int page = 1, int pageSize = 50, string sort = null);
+        JobRunDto GetJobRunById(long jobRunId);
+    }
+}

--- a/source/Jobbr.Client/JobbrClient.cs
+++ b/source/Jobbr.Client/JobbrClient.cs
@@ -2,6 +2,8 @@
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+
 using Jobbr.Server.WebAPI.Model;
 using Newtonsoft.Json;
 
@@ -19,12 +21,13 @@ namespace Jobbr.Client
 
         public string Backend { get; }
 
-        public JobDto GetJob(long id)
+        public JobDto GetJob(long id) => this.GetJobAsync(id).Result;
+        public async Task<JobDto> GetJobAsync(long id)
         {
             var url = $"jobs/{id}";
 
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            var response = this.httpClient.SendAsync(request).Result;
+            var response = await this.httpClient.SendAsync(request);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -38,17 +41,19 @@ namespace Jobbr.Client
             return null;
         }
 
-        public bool IsAvailable()
+        public bool IsAvailable() => this.IsAvailableAsync().Result;
+        public async Task<bool> IsAvailableAsync()
         {
             const string url = "status";
 
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            var response = this.httpClient.SendAsync(request).Result;
+            var response = await this.httpClient.SendAsync(request);
 
             return response.StatusCode == HttpStatusCode.OK;
         }
 
-        public PagedResultDto<JobDto> QueryJobs(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
+        public PagedResultDto<JobDto> QueryJobs(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null) => this.QueryJobsAsync(page, pageSize, jobTypeFilter, jobUniqueNameFilter, query, sort).Result;
+        public async Task<PagedResultDto<JobDto>> QueryJobsAsync(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
         {
             var url = $"jobs?page={page}&pageSize={pageSize}&jobTypeFilter={jobTypeFilter}&jobUniqueNameFilter={jobUniqueNameFilter}&query={query}&sort={sort}";
 
@@ -57,7 +62,7 @@ namespace Jobbr.Client
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var contentString = response.Content.ReadAsStringAsync().Result;
+                var contentString = await response.Content.ReadAsStringAsync();
 
                 var responseDto = JsonConvert.DeserializeObject<PagedResultDto<JobDto>>(contentString);
 
@@ -67,7 +72,8 @@ namespace Jobbr.Client
             return null;
         }
 
-        public PagedResultDto<JobRunDto> QueryJobRuns(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
+        public PagedResultDto<JobRunDto> QueryJobRuns(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null) => this.QueryJobRunsAsync(page, pageSize, jobTypeFilter, jobUniqueNameFilter, query, sort).Result;
+        public async Task<PagedResultDto<JobRunDto>> QueryJobRunsAsync(int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
         {
             var url = $"jobRuns?page={page}&pageSize={pageSize}&jobTypeFilter={jobTypeFilter}&jobUniqueNameFilter={jobUniqueNameFilter}&query={query}&sort={sort}";
 
@@ -76,7 +82,7 @@ namespace Jobbr.Client
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var contentString = response.Content.ReadAsStringAsync().Result;
+                var contentString = await response.Content.ReadAsStringAsync();
 
                 var responseDto = JsonConvert.DeserializeObject<PagedResultDto<JobRunDto>>(contentString);
 
@@ -86,7 +92,8 @@ namespace Jobbr.Client
             return null;
         }
 
-        public PagedResultDto<JobRunDto> QueryJobRunsByState(string state, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
+        public PagedResultDto<JobRunDto> QueryJobRunsByState(string state, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null) => this.QueryJobRunsByStateAsync(state, page, pageSize, jobTypeFilter, jobUniqueNameFilter, query, sort).Result;
+        public async Task<PagedResultDto<JobRunDto>> QueryJobRunsByStateAsync(string state, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
         {
             var url = $"jobRuns?page={page}&pageSize={pageSize}&jobTypeFilter={jobTypeFilter}&jobUniqueNameFilter={jobUniqueNameFilter}&query={query}&sort={sort}&state={state}";
 
@@ -95,7 +102,7 @@ namespace Jobbr.Client
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var contentString = response.Content.ReadAsStringAsync().Result;
+                var contentString = await response.Content.ReadAsStringAsync();
 
                 var responseDto = JsonConvert.DeserializeObject<PagedResultDto<JobRunDto>>(contentString);
 
@@ -105,7 +112,8 @@ namespace Jobbr.Client
             return null;
         }
 
-        public PagedResultDto<JobRunDto> QueryJobRunsByStates(string states, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
+        public PagedResultDto<JobRunDto> QueryJobRunsByStates(string states, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null) => this.QueryJobRunsByStatesAsync(states, page, pageSize, jobTypeFilter, jobUniqueNameFilter, query, sort).Result;
+        public async Task<PagedResultDto<JobRunDto>> QueryJobRunsByStatesAsync(string states, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string query = null, string sort = null)
         {
             var url = $"jobRuns?page={page}&pageSize={pageSize}&jobTypeFilter={jobTypeFilter}&jobUniqueNameFilter={jobUniqueNameFilter}&query={query}&sort={sort}&states={states}";
 
@@ -114,7 +122,7 @@ namespace Jobbr.Client
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var contentString = response.Content.ReadAsStringAsync().Result;
+                var contentString = await response.Content.ReadAsStringAsync();
 
                 var responseDto = JsonConvert.DeserializeObject<PagedResultDto<JobRunDto>>(contentString);
 
@@ -124,7 +132,8 @@ namespace Jobbr.Client
             return null;
         }
 
-        public PagedResultDto<JobRunDto> QueryJobRunsByUserId(string userId, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string sort = null)
+        public PagedResultDto<JobRunDto> QueryJobRunsByUserId(string userId, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string sort = null) => this.QueryJobRunsByUserIdAsync(userId, page, pageSize, jobTypeFilter, jobUniqueNameFilter, sort).Result;
+        public async Task<PagedResultDto<JobRunDto>> QueryJobRunsByUserIdAsync(string userId, int page = 1, int pageSize = 50, string jobTypeFilter = null, string jobUniqueNameFilter = null, string sort = null)
         {
             var url = $"users/{userId}/jobruns/?page={page}&pageSize={pageSize}&jobTypeFilter={jobTypeFilter}&jobUniqueNameFilter={jobUniqueNameFilter}&sort={sort}";
 
@@ -133,7 +142,7 @@ namespace Jobbr.Client
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var contentString = response.Content.ReadAsStringAsync().Result;
+                var contentString = await response.Content.ReadAsStringAsync();
 
                 var responseDto = JsonConvert.DeserializeObject<PagedResultDto<JobRunDto>>(contentString);
 
@@ -143,35 +152,40 @@ namespace Jobbr.Client
             return null;
         }
 
-        public T AddTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase
+        public T AddTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase => this.AddTriggerAsync<T>(jobId, triggerDto).Result;
+        public T AddTrigger<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase => this.AddTriggerAsync<T>(uniqueName, triggerDto).Result;
+
+        public async Task<T> AddTriggerAsync<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase
         {
             var url = $"jobs/{jobId}/triggers";
-            return this.PostTrigger(triggerDto, url);
+            return await this.PostTrigger(triggerDto, url);
         }
-
-        public T AddTrigger<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase
+        public async Task<T> AddTriggerAsync<T>(string uniqueName, T triggerDto) where T : JobTriggerDtoBase
         {
             var url = $"jobs/{uniqueName}/triggers/{triggerDto.Id}";
-            return this.PostTrigger(triggerDto, url);
+            return await this.PostTrigger(triggerDto, url);
         }
 
-        public T UpdateTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase
+        public T UpdateTrigger<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase => this.UpdateTriggerAsync<T>(jobId, triggerDto).Result;
+        public async Task<T> UpdateTriggerAsync<T>(long jobId, T triggerDto) where T : JobTriggerDtoBase
         {
             var url = $"jobs/{jobId}/triggers/{triggerDto.Id}";
-            return this.PatchTrigger(triggerDto, url);
+            return await this.PatchTrigger(triggerDto, url);
         }
 
-        public T GetTriggerById<T>(long jobId, long triggerId) where T : JobTriggerDtoBase
+        public T GetTriggerById<T>(long jobId, long triggerId) where T : JobTriggerDtoBase => this.GetTriggerByIdAsync<T>(jobId, triggerId).Result;
+        public async Task<T> GetTriggerByIdAsync<T>(long jobId, long triggerId) where T : JobTriggerDtoBase
         {
             var url = $"jobs/{jobId}/triggers/{triggerId}";
-            return this.GetTrigger<T>(url);
+            return await this.GetTrigger<T>(url);
         }
 
-        public PagedResultDto<JobRunDto> GetJobRunsByTriggerId(long jobId, long triggerId, int page = 1, int pageSize = 50, string sort = null)
+        public PagedResultDto<JobRunDto> GetJobRunsByTriggerId(long jobId, long triggerId, int page = 1, int pageSize = 50, string sort = null) => this.GetJobRunsByTriggerIdAsync(jobId, triggerId, page, pageSize, sort).Result;
+        public async Task<PagedResultDto<JobRunDto>> GetJobRunsByTriggerIdAsync(long jobId, long triggerId, int page = 1, int pageSize = 50, string sort = null)
         {
             var url = $"jobs/{jobId}/triggers/{triggerId}/jobruns?page={page}&pageSize={pageSize}&sort={sort}";
 
-            var requestResult = this.httpClient.GetAsync(url).Result;
+            var requestResult = await this.httpClient.GetAsync(url);
 
             if (requestResult.StatusCode == HttpStatusCode.OK)
             {
@@ -185,11 +199,12 @@ namespace Jobbr.Client
             return null;
         }
 
-        public JobRunDto GetJobRunById(long jobRunId)
+        public JobRunDto GetJobRunById(long jobRunId) => this.GetJobRunByIdAsync(jobRunId).Result;
+        public async Task<JobRunDto> GetJobRunByIdAsync(long jobRunId)
         {
             var url = $"jobruns/{jobRunId}";
 
-            var requestResult = this.httpClient.GetAsync(url).Result;
+            var requestResult = await this.httpClient.GetAsync(url);
 
             if (requestResult.StatusCode == HttpStatusCode.OK)
             {
@@ -203,27 +218,22 @@ namespace Jobbr.Client
             return null;
         }
 
-        private T PostTrigger<T>(T triggerDto, string url) where T : JobTriggerDtoBase
+        private async Task<T> PostTrigger<T>(T triggerDto, string url) where T : JobTriggerDtoBase
         {
-            return this.ExecuteDtoRequest(url, triggerDto, HttpMethod.Post);
+            return await this .ExecuteDtoRequest(url, triggerDto, HttpMethod.Post);
         }
 
-        private T PatchTrigger<T>(T triggerDto, string url) where T : JobTriggerDtoBase
+        private async Task<T> PatchTrigger<T>(T triggerDto, string url) where T : JobTriggerDtoBase
         {
-            return this.ExecuteDtoRequest(url, triggerDto, new HttpMethod("PATCH"));
+            return await this.ExecuteDtoRequest(url, triggerDto, new HttpMethod("PATCH"));
         }
 
-        private T GetTrigger<T>(string url) where T : class
+        private async Task<T> GetTrigger<T>(string url) where T : class
         {
-            return this.ExecuteDtoRequest<T>(url, null, HttpMethod.Get);
+            return await this.ExecuteDtoRequest<T>(url, null, HttpMethod.Get);
         }
 
-        private T GetTriggers<T>(string url) where T : class
-        {
-            return this.ExecuteDtoRequest<T>(url, null, HttpMethod.Get);
-        }
-
-        private T ExecuteDtoRequest<T>(string url, T dto, HttpMethod httpMethod) where T : class
+        private async Task<T> ExecuteDtoRequest<T>(string url, T dto, HttpMethod httpMethod) where T : class
         {
             var json = dto != null ? JsonConvert.SerializeObject(dto) : string.Empty;
             var request = new HttpRequestMessage(httpMethod, url);
@@ -233,7 +243,7 @@ namespace Jobbr.Client
                 request.Content = new StringContent(json, Encoding.UTF8, "application/json");
             }
 
-            var response = this.httpClient.SendAsync(request).Result;
+            var response = await this.httpClient.SendAsync(request);
 
             if (response.StatusCode == HttpStatusCode.Created || response.StatusCode == HttpStatusCode.OK)
             {

--- a/source/Jobbr.Client/JobbrClient.cs
+++ b/source/Jobbr.Client/JobbrClient.cs
@@ -1,21 +1,19 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.Serialization;
 using System.Text;
 using Jobbr.Server.WebAPI.Model;
 using Newtonsoft.Json;
 
 namespace Jobbr.Client
 {
-    public class JobbrClient
+    public class JobbrClient : IJobbrClient
     {
         private readonly HttpClient httpClient;
 
         public JobbrClient(string backend)
         {
-            this.Backend = backend + (backend.EndsWith("/") ? string.Empty  : "/");
+            this.Backend = backend + (backend.EndsWith("/") ? string.Empty : "/");
             this.httpClient = new HttpClient { BaseAddress = new Uri(this.Backend) };
         }
 
@@ -225,7 +223,7 @@ namespace Jobbr.Client
             return this.ExecuteDtoRequest<T>(url, null, HttpMethod.Get);
         }
 
-        private T ExecuteDtoRequest<T>(string url, T dto, HttpMethod httpMethod) where T: class
+        private T ExecuteDtoRequest<T>(string url, T dto, HttpMethod httpMethod) where T : class
         {
             var json = dto != null ? JsonConvert.SerializeObject(dto) : string.Empty;
             var request = new HttpRequestMessage(httpMethod, url);


### PR DESCRIPTION
This PR aims to
- provide an interface for its exposed JobbrClient implementation, so that consumer applications can use this for DI registrations. Otherwise, there will always be the need to implement a facade interface.
- Provide async Method overloads, so the consumer application can decide by them self, if they want to use sync over asnyc (this prevents the drawback of mixing async with sync task scedhuling overhead in .net)
- Lifts .csproj target framework to most commonly used 4.7.2. This is also used within some other projects (see standalone projects
- Lift .nuspec lib target framework to .net 4.7.2

I was thinking about lifting to 4.8 so one could use language version 8 and therefore handle interface default implementations for async overload within the interface to not pollute the class but .net 4.8 is not as widely used as 4.7.
