### PR TITLE
Fix bad DTO mappings

### DIFF
--- a/source/Jobbr.Server.WebAPI/Controller/Mapping/TriggerMapper.cs
+++ b/source/Jobbr.Server.WebAPI/Controller/Mapping/TriggerMapper.cs
@@ -78,12 +78,28 @@ namespace Jobbr.Server.WebAPI.Controller.Mapping
         }
 
         /// <summary>
+        /// Maps common trigger values to a paged DTO result.
+        /// </summary>
+        /// <param name="data">Paged result of trigger that use the <see cref="IJobTrigger"/> interface.</param>
+        /// <returns>Paged result of the base class with the trigger values.</returns>
+        internal static PagedResultDto<JobTriggerDtoBase> ToPagedResult(this PagedResult<IJobTrigger> data)
+        {
+            return new PagedResultDto<JobTriggerDtoBase>
+            {
+                Page = data.Page,
+                PageSize = data.PageSize,
+                Items = data.Items.Select(t => ConvertToDto((dynamic)t)).Cast<JobTriggerDtoBase>().ToList(),
+                TotalItems = data.TotalItems
+            };
+        }
+
+        /// <summary>
         /// Maps common trigger values.
         /// </summary>
         /// <param name="trigger">Trigger that uses the <see cref="IJobTrigger"/> interface.</param>
         /// <param name="dto">Base class <see cref="JobTriggerDtoBase"/>.</param>
         /// <returns>Base class with the mapped values.</returns>
-        internal static JobTriggerDtoBase MapCommonValues(IJobTrigger trigger, JobTriggerDtoBase dto)
+        private static JobTriggerDtoBase MapCommonValues(IJobTrigger trigger, JobTriggerDtoBase dto)
         {
             dto.Id = trigger.Id;
             dto.Comment = trigger.Comment;
@@ -102,32 +118,16 @@ namespace Jobbr.Server.WebAPI.Controller.Mapping
         /// <param name="dto">Base class <see cref="JobTriggerDtoBase"/>.</param>
         /// <param name="trigger">Trigger that uses the <see cref="IJobTrigger"/> interface.</param>
         /// <returns>Trigger class with the mapped values.</returns>
-        internal static IJobTrigger MapCommonValues(JobTriggerDtoBase dto, IJobTrigger trigger)
+        private static IJobTrigger MapCommonValues(JobTriggerDtoBase dto, IJobTrigger trigger)
         {
             trigger.Comment = dto.Comment;
             trigger.IsActive = dto.IsActive;
-            trigger.Parameters = JsonSerializer.Serialize(dto.Parameters, DefaultJsonOptions.Options);
+            trigger.Parameters = trigger.Parameters is null ? null : JsonSerializer.Serialize(dto.Parameters, DefaultJsonOptions.Options);
             trigger.UserDisplayName = dto.UserDisplayName;
             trigger.UserId = dto.UserId;
             trigger.Deleted = dto.Deleted;
 
             return trigger;
-        }
-
-        /// <summary>
-        /// Maps common trigger values to a paged DTO result.
-        /// </summary>
-        /// <param name="data">Paged result of trigger that use the <see cref="IJobTrigger"/> interface.</param>
-        /// <returns>Paged result of the base class with the trigger values.</returns>
-        internal static PagedResultDto<JobTriggerDtoBase> ToPagedResult(this PagedResult<IJobTrigger> data)
-        {
-            return new PagedResultDto<JobTriggerDtoBase>
-            {
-                Page = data.Page,
-                PageSize = data.PageSize,
-                Items = data.Items.Select(t => ConvertToDto((dynamic)t)).Cast<JobTriggerDtoBase>().ToList(),
-                TotalItems = data.TotalItems
-            };
         }
     }
 }

--- a/source/Jobbr.Server.WebAPI/Controller/TriggerController.cs
+++ b/source/Jobbr.Server.WebAPI/Controller/TriggerController.cs
@@ -75,9 +75,13 @@ namespace Jobbr.Server.WebAPI.Controller
 
             if (dto is RecurringTriggerDto recurringTriggerDto)
             {
+                var existingTrigger = (RecurringTrigger)currentTrigger;
                 var trigger = TriggerMapper.ConvertToTrigger(recurringTriggerDto);
                 trigger.Id = triggerId;
                 trigger.JobId = jobId;
+                trigger.Definition = recurringTriggerDto.Definition ?? existingTrigger.Definition;
+                trigger.StartDateTimeUtc = recurringTriggerDto.StartDateTimeUtc ?? existingTrigger.StartDateTimeUtc;
+                trigger.EndDateTimeUtc = recurringTriggerDto.EndDateTimeUtc ?? existingTrigger.EndDateTimeUtc;
 
                 _jobManagementService.Update(trigger);
             }

--- a/source/Jobbr.WebAPI.Tests/ClientTests.cs
+++ b/source/Jobbr.WebAPI.Tests/ClientTests.cs
@@ -317,12 +317,18 @@ namespace Jobbr.WebAPI.Tests
         {
             using (GivenRunningServerWithWebApi())
             {
+                const string definition = "0 0 * * 6";
+
                 var client = new JobbrClient(BackendAddress);
 
                 var job = new Job();
                 JobStorage.AddJob(job);
 
-                var trigger = new RecurringTrigger();
+                var trigger = new RecurringTrigger
+                {
+                    Definition = definition
+                };
+
                 JobStorage.AddTrigger(job.Id, trigger);
 
                 var triggerDto = client.UpdateTrigger(job.Id, new RecurringTriggerDto { Id = trigger.Id, IsActive = true });
@@ -330,9 +336,11 @@ namespace Jobbr.WebAPI.Tests
                 Assert.IsNotNull(triggerDto);
                 Assert.IsTrue(triggerDto.IsActive);
 
-                var trigger2 = JobStorage.GetTriggerById(job.Id, trigger.Id);
+                var trigger2 = (RecurringTrigger)JobStorage.GetTriggerById(job.Id, trigger.Id);
 
                 Assert.IsTrue(trigger2.IsActive);
+                Assert.IsNotNull(trigger2.Definition);
+                Assert.IsTrue(trigger2.Definition == definition);
             }
         }
 


### PR DESCRIPTION
When receiving the DTO from the front-end, it doesn't correctly map the properties for Recurring Triggers and also wrongly parses null strings for the parameters field